### PR TITLE
Version 3 compatibility update

### DIFF
--- a/acf-{{field_name}}.php
+++ b/acf-{{field_name}}.php
@@ -36,7 +36,7 @@ class acf_field_{{field_name}}_plugin
 
 		
 		// version 3-
-		add_action( 'init', array( $this, 'init' ));
+		add_action( 'init', array( $this, 'init' ), 5);
 	}
 	
 	


### PR DESCRIPTION
Fixes a bug that if your plugin is alphabetically named after "advanced" it's loaded after ACF, and too late to actually be included in the field list
